### PR TITLE
Added tada icons for milestone completion

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -213,6 +213,16 @@ const Page = {
       let tr = document.createElement("tr");
 
       {
+          let td = document.createElement("td");
+          td.innerHTML = `${String.fromCodePoint(0x1F389)}`;
+
+          if (milestonesStatus[i - 1] !== "100%") {
+            td.style.opacity = "0";
+          }
+
+          tr.appendChild(td);
+      }
+      {
         let td = document.createElement("td");
         td.innerHTML = milestone.code;
         tr.appendChild(td);
@@ -226,6 +236,16 @@ const Page = {
         let td = document.createElement("td");
         td.innerHTML = milestonesStatus[i - 1];
         tr.appendChild(td);
+      }
+      {
+          let td = document.createElement("td");
+          td.innerHTML = `${String.fromCodePoint(0x1F389)}`;
+
+          if (milestonesStatus[i - 1] !== "100%") {
+            td.style.opacity = "0";
+          }
+
+          tr.appendChild(td);
       }
       if (State.activeMilestone == milestone.code) {
         tr.classList.add("active");


### PR DESCRIPTION
A simple change that adds tada/celebration icons if one milestone hits 100%.

Related to #16, but may not be the only change. :)

### Dashboard milestones list without completion
![image](https://user-images.githubusercontent.com/25045015/134081547-98570bcc-540c-4d7f-907d-a7c3ab131d8a.png)

### Dashboard milestones list with completion
![image](https://user-images.githubusercontent.com/25045015/134081680-03ae1dc8-8f50-4511-8d0d-8e46a4cf9260.png)

### Current milestones list
![image](https://user-images.githubusercontent.com/25045015/134081800-4354fc79-efbc-4d03-a072-80c9bb64da4b.png)