### PR TITLE
Add automated daily updates for M3 data

### DIFF
--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -1,0 +1,42 @@
+name: Update
+on:
+  schedule:
+    - cron: "0 6 * * *" # Daily at 6AM UTC
+  workflow_dispatch:
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout main branch
+        uses: actions/checkout@v3
+      - name: Checkout gh-pages branch
+        uses: actions/checkout@v3
+        with:
+          ref: gh-pages
+          path: gh-pages
+      - name: Checkout mozilla/gecko-dev
+        uses: actions/checkout@v3
+        with:
+          repository: mozilla/gecko-dev
+          path: gecko-dev
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+          cache: pip
+      - run: pip install -r requirements.txt
+
+      - name: Generate new data
+        run: >
+          python src/arewefluentyet/aggregate.py
+          --mc ./gecko-dev --git --gh-pages-data gh-pages/data
+          -m M3 --use-current-revision
+      - name: Update gh-pages branch
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git add .
+          git commit -m "$(git -C ../gecko-dev show -s --format=%cs)"
+          git push
+        working-directory: ./gh-pages

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.pyc
+.*
 /gh-pages

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.pyc
 .*
+/gecko-dev
 /gh-pages

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+compare-locales>=8.2

--- a/src/arewefluentyet/aggregate.py
+++ b/src/arewefluentyet/aggregate.py
@@ -37,10 +37,11 @@ def update_milestones_for_revision(
         source: Source, milestones: Milestones, revision, use_current_revision):
     for milestone in milestones:
         rev_date = source.get_revision_date(revision, use_current_revision)
-        milestone_last_date = milestone.get_last_date()
-        if milestone_last_date and rev_date <= milestone_last_date:
-            print(f"   - {milestone.name}: Skipping (Already collected)")
-            continue
+        if not use_current_revision:
+            milestone_last_date = milestone.get_last_date()
+            if milestone_last_date and rev_date <= milestone_last_date:
+                print(f"   - {milestone.name}: Skipping (Already collected)")
+                continue
         result = milestone.collect_data(source, rev_date, revision)
         if result is None:
             print(f"   - {milestone.name}: Skipping (User aborted)")

--- a/src/arewefluentyet/aggregate.py
+++ b/src/arewefluentyet/aggregate.py
@@ -5,7 +5,7 @@ import os
 from milestone1 import Milestone1
 from milestone2 import Milestone2
 from milestone3 import Milestone3
-from source import HgSource, Source
+from source import GitSource, HgSource, Source
 
 PARAMS = {
     "frequency": timedelta(days=7),
@@ -164,6 +164,9 @@ if __name__ == "__main__":
                         required=True,
                         metavar='../mozilla-unified',
                         help='Path to mozilla-central clone')
+    parser.add_argument('--git',
+                        action='store_true',
+                        help='Work with a git rather than hg mozilla-central clone')
     parser.add_argument('--gh-pages-data',
                         required=True,
                         metavar='../awfy/gh-pages/data',
@@ -174,7 +177,10 @@ if __name__ == "__main__":
     milestones = set_milestones(parser, args)
 
     verify_mc_path(parser, args.mc)
-    source = HgSource(args.mc)
+    if args.git:
+        source = GitSource(args.mc)
+    else:
+        source = HgSource(args.mc)
 
     PARAMS["dry_run"] = args.dry_run
 

--- a/src/arewefluentyet/aggregate.py
+++ b/src/arewefluentyet/aggregate.py
@@ -1,10 +1,11 @@
 import argparse
+from datetime import date, timedelta
 import os
+
 from milestone1 import Milestone1
 from milestone2 import Milestone2
 from milestone3 import Milestone3
-from source import Source
-from datetime import timedelta
+from source import HgSource, Source
 
 PARAMS = {
     "frequency": timedelta(days=7),
@@ -15,7 +16,7 @@ Milestones = list[Milestone1 | Milestone2 | Milestone3]
 
 
 def get_next_date(milestones: Milestones):
-    next_date = None
+    next_date: date = None  # type: ignore
 
     for milestone in milestones:
         candidate = milestone.get_next_date(PARAMS["frequency"])
@@ -173,7 +174,7 @@ if __name__ == "__main__":
     milestones = set_milestones(parser, args)
 
     verify_mc_path(parser, args.mc)
-    source = Source(args.mc)
+    source = HgSource(args.mc)
 
     PARAMS["dry_run"] = args.dry_run
 

--- a/src/arewefluentyet/data.py
+++ b/src/arewefluentyet/data.py
@@ -24,7 +24,7 @@ class Aggregator(object):
 
     def gather(self):
         fls = files.ProjectFiles("en-US", self.configs)
-        results = [{} for cfg in self.configs]
+        results: list[dict[str, int]] = [{} for _ in self.configs]
         for l10n_path, f, _, tests in fls:
             if "android-dtd" in tests:
                 # ignore Android native strings
@@ -36,7 +36,8 @@ class Aggregator(object):
             p.readFile(f)
             string_count = len(list(p))
             for i, cfg in enumerate(self.configs):
-                l10n_file = paths.File(l10n_path, mozpath.relpath(l10n_path, mozpath.abspath(".")), locale='en-US')
+                l10n_file = paths.File(l10n_path, mozpath.relpath(
+                    l10n_path, mozpath.abspath(".")), locale='en-US')
                 if cfg.filter(l10n_file) != "ignore":
                     results[i][l10n_file.file] = string_count
         return results

--- a/src/arewefluentyet/milestone.py
+++ b/src/arewefluentyet/milestone.py
@@ -16,7 +16,11 @@ class Milestone:
         self.progress_data = None
 
     def append_progress_entry(self, progress_entry):
-        self.get_progress_data().append(progress_entry)
+        progress_data = self.get_progress_data()
+        if progress_data[-1]["date"] == progress_entry["date"]:
+            progress_data[-1] = progress_entry
+        else:
+            progress_data.append(progress_entry)
 
     def get_progress_data(self):
         if self.progress_data is None:

--- a/src/arewefluentyet/milestone.py
+++ b/src/arewefluentyet/milestone.py
@@ -1,6 +1,6 @@
 import os
 import json
-from datetime import date
+from datetime import date, timedelta
 
 
 def parse_date(input):
@@ -8,8 +8,8 @@ def parse_date(input):
 
 
 class Milestone:
-    name = None
-    start_date = None
+    name: str = None  # type: ignore
+    start_date: date = None  # type: ignore
 
     def __init__(self, data_path):
         self.data_path = os.path.join(data_path, self.name)
@@ -37,7 +37,7 @@ class Milestone:
         """
         return False
 
-    def get_data(self, date, revision):
+    def get_data(self, source, date, revision) -> tuple[list[dict[str, str | int]], dict[str, int]]:
         raise NotImplementedError
 
     def collect_data(self, source, date, revision):
@@ -57,7 +57,7 @@ class Milestone:
 
         return (progress_entry, snapshot)
 
-    def get_next_date(self, frequency):
+    def get_next_date(self, frequency: timedelta):
         progress_data = self.get_progress_data()
         if len(progress_data) > 0:
             return parse_date(progress_data[-1]["date"]) + frequency

--- a/src/arewefluentyet/milestone1.py
+++ b/src/arewefluentyet/milestone1.py
@@ -2,17 +2,19 @@ import os
 import re
 from collections import defaultdict
 from datetime import date
-from milestone import Milestone
 from functools import partial
+from milestone import Milestone
+from source import Source
 
 HTML_ENTITIES = ["quot", "amp", "nbsp", "lt", "gt"]
+
 
 class Milestone1(Milestone):
     name = "M1"
     start_date = date(2019, 3, 24)
     main_file = "./browser/base/content/browser.xhtml"
 
-    def get_data(self, source, date, revision):
+    def get_data(self, source: Source, date, revision):
         entries = []
         self.matches_in_file(self.main_file, entries, source.path)
 

--- a/src/arewefluentyet/milestone2.py
+++ b/src/arewefluentyet/milestone2.py
@@ -22,20 +22,23 @@ class Milestone2(Milestone):
 
     def get_data(self, source, date, revision):
         if not self.has_log_for_date(source, date):
-            response = input(f"About to attempt to apply the `collect-startup-entries` onto {revision} (Y/N): ")
+            response = input(
+                f"About to attempt to apply the `collect-startup-entries` onto {revision} (Y/N): ")
             if response.lower() != "y":
                 return None
             source.rebase_bookmark(revision, self.bookmark)
             source.switch_to_revision(self.bookmark)
 
-            response = input("About to build Firefox with the `collect-startup-entries` (Y/N): ")
+            response = input(
+                "About to build Firefox with the `collect-startup-entries` (Y/N): ")
             if response.lower() != "y":
                 return None
 
             print(f"Building Firefox with `collect-startup-entries`. You can see the progress via `tail -f firefox-build-log.txt`.")
             source.build_firefox()
 
-            response = input("About to launch Firefox with `collect-startup-entries` (Y/N): ")
+            response = input(
+                "About to launch Firefox with `collect-startup-entries` (Y/N): ")
             if response.lower() != "y":
                 return None
 
@@ -70,7 +73,7 @@ class Milestone2(Milestone):
         matches = re.finditer("== Entry ==(.*?)== Entry End ==",
                               raw_data, re.DOTALL | re.MULTILINE)
         for match in matches:
-            entry = {
+            entry: dict[str, str | None] = {
                 "type": None,
                 "id": None,
                 "stack": None,
@@ -89,9 +92,10 @@ class Milestone2(Milestone):
                     stack = True
                     entry["stack"] = ""
                 elif stack and len(line) > 0:
-                    entry["stack"] += line + "\n"
+                    entry["stack"] += line + "\n"  # type: ignore
             if entry["stack"] is not None:
-                entry["stack"] = self.parse_stack(entry["stack"])
+                entry["stack"] = self.parse_stack(  # type: ignore
+                    entry["stack"])
 
             if entry["type"] == "dtd":
                 context = self.find_context(contexts, match.start())
@@ -107,7 +111,7 @@ class Milestone2(Milestone):
             "properties": 0
         }
         for entry in entries:
-            progress[entry["type"]] += 1
+            progress[entry["type"]] += 1  # type: ignore
 
         return (entries, progress)
 
@@ -117,7 +121,8 @@ class Milestone2(Milestone):
         for line in stack.split("\n"):
             if len(line.strip()) == 0:
                 continue
-            match = re.match("([0-9]+) (.*?) \[\"([^\"]+)\":([0-9]+):([0-9]+)]", line)
+            match = re.match(
+                "([0-9]+) (.*?) \[\"([^\"]+)\":([0-9]+):([0-9]+)]", line)
             if match is None:
                 print(line)
                 continue

--- a/src/arewefluentyet/milestone3.py
+++ b/src/arewefluentyet/milestone3.py
@@ -1,7 +1,9 @@
-from data import Aggregator
 import os
 from collections import defaultdict
 from datetime import date
+
+from data import Aggregator
+from source import Source
 from milestone import Milestone
 
 
@@ -9,7 +11,7 @@ class Milestone3(Milestone):
     name = "M3"
     start_date = date(2017, 11, 1)
 
-    def get_data(self, source, date, revision):
+    def get_data(self, source: Source, date, revision):
         aggregator = Aggregator(
             [os.path.join(source.path, "browser/locales/l10n.toml")])
         aggregator.load()
@@ -19,9 +21,9 @@ class Milestone3(Milestone):
         (entries, progress) = self.extract_progress(result)
         return (entries, progress)
 
-    def extract_progress(self, dataset):
-        entries = []
-        progress = defaultdict(int)
+    def extract_progress(self, dataset: list[dict[str, int]]):
+        entries: list[dict[str, str | int]] = []
+        progress: defaultdict[str, int] = defaultdict(int)
 
         for subset in dataset:
             for path, count in subset.items():

--- a/src/arewefluentyet/source.py
+++ b/src/arewefluentyet/source.py
@@ -8,10 +8,35 @@ def parse_date(input):
 
 
 class Source:
+    current_revision: str | None = None
+    path: str
+
     def __init__(self, path: str):
         self.path = path
         self.current_revision = None
 
+    def get_current_revision(self) -> str:
+        raise NotImplementedError
+
+    def pick_next_revision(self, next_date: date) -> str:
+        raise NotImplementedError
+
+    def get_revision_date(self, rev: str, use_current_revision: bool) -> date:
+        raise NotImplementedError
+
+    def switch_to_revision(self, rev: str) -> None:
+        raise NotImplementedError
+
+    def rebase_bookmark(self, revision: str, bookmark: str) -> None:
+        raise NotImplementedError
+
+    def build_firefox(self):
+        cmd = os.path.join(self.path, "mach")
+        with open("firefox-build-log.txt", "w") as fp:
+            subprocess.run([cmd, "build"], stdout=fp, check=True)
+
+
+class HgSource(Source):
     def get_current_revision(self):
         if not self.current_revision:
             result = subprocess.run([
@@ -75,8 +100,3 @@ class Source:
                 "hg", "rebase", "--cwd", self.path,
                 "-b", bookmark, "-d", revision
             ], check=True, stdout=subprocess.DEVNULL)
-
-    def build_firefox(self):
-        cmd = os.path.join(self.path, "mach")
-        with open("firefox-build-log.txt", "w") as fp:
-            subprocess.run([cmd, "build"], stdout=fp, check=True)

--- a/src/arewefluentyet/source.py
+++ b/src/arewefluentyet/source.py
@@ -8,7 +8,7 @@ def parse_date(input):
 
 
 class Source:
-    def __init__(self, path):
+    def __init__(self, path: str):
         self.path = path
         self.current_revision = None
 
@@ -36,12 +36,12 @@ class Source:
             result = subprocess.run([
                 "hg", "id", "--cwd", self.path,
                 "-r", rev, "-T", "{date|shortdate}"
-                ], check=True, capture_output=True, encoding="ascii")
+            ], check=True, capture_output=True, encoding="ascii")
         else:
             result = subprocess.run([
                 "hg", "id", "--cwd", self.path,
                 "-r", rev, "-T", "{pushdate|shortdate}"
-                ], check=True, capture_output=True, encoding="ascii")
+            ], check=True, capture_output=True, encoding="ascii")
 
         return parse_date(result.stdout)
 

--- a/src/arewefluentyet/source.py
+++ b/src/arewefluentyet/source.py
@@ -8,7 +8,7 @@ def parse_date(input):
 
 
 class Source:
-    current_revision: str | None = None
+    current_revision: str | None
     path: str
 
     def __init__(self, path: str):

--- a/src/arewefluentyet/source.py
+++ b/src/arewefluentyet/source.py
@@ -36,6 +36,31 @@ class Source:
             subprocess.run([cmd, "build"], stdout=fp, check=True)
 
 
+class GitSource(Source):
+    def get_current_revision(self):
+        if not self.current_revision:
+            result = subprocess.run([
+                "git", "--no-pager", "-C", self.path,
+                "show", "--no-patch", "--format=%h"
+            ], check=True, capture_output=True, encoding="ascii")
+            self.current_revision = result.stdout.strip()
+        return self.current_revision
+
+    def get_revision_date(self, rev, use_current_revision):
+        if use_current_revision:
+            result = subprocess.run([
+                "git", "--no-pager", "-C", self.path,
+                "show", "--no-patch", "--format=%cs"
+            ], check=True, capture_output=True, encoding="ascii")
+        else:
+            result = subprocess.run([
+                "git", "--no-pager", "-C", self.path,
+                "show", "--no-patch", "--format=%cs", rev
+            ], check=True, capture_output=True, encoding="ascii")
+
+        return parse_date(result.stdout)
+
+
 class HgSource(Source):
     def get_current_revision(self):
         if not self.current_revision:


### PR DESCRIPTION
See #22 
CC @nordzilla, @zbraniecki 

This adds a minimally functional `GitSource` as an alternative to `HgSource` (previously just `Source`) and a corresponding CLI option `--git`, which lets the script work with git repositories as well as Mercurial ones. For now, this functionality only extends to the features used by `--use-current-revision`.

Using that, a scheduled (daily at 6AM UTC) GitHub Actions task is added which checks out the latest commit (i.e. "central") from the [mozilla/gecko-dev](https://github.com/mozilla/gecko-dev) mirror and generates the M3 data for it, and then updates the `gh-pages` branch.

To effect these changes and get a decent grasp of what the script is really doing, I've added some type hints which effectively require Python 3.9, and a pip `requirements.txt` file.

Before merging this, we should update the last few weeks' data to the `gh-pages` branch, as this script will only run on the latest commit.

To test the action, I've been manually running it on my fork of this repo: https://github.com/eemeli/arewefluentyet.com/actions/workflows/update.yaml